### PR TITLE
Add Jekyll configuration for GitHub Pages deployment

### DIFF
--- a/docs/_config.yml
+++ b/docs/_config.yml
@@ -1,0 +1,80 @@
+# Site settings
+title: "AI Development Documentation"
+description: "Documentation for AI development tools and configurations"
+url: "https://cowboylogic.github.io"  # Replace with your GitHub Pages URL
+baseurl: "/ai-dev"  # Replace with your repository name
+
+# Build settings
+markdown: kramdown
+highlighter: rouge
+
+# Remote theme (GitHub Pages supported)
+remote_theme: pages-themes/slate@v0.2.0
+
+# Plugins (GitHub Pages supported only)
+plugins:
+  - jekyll-remote-theme
+  - jekyll-paginate
+  - jekyll-gist
+  - jekyll-github-metadata
+
+# Collections
+collections:
+  agents:
+    output: true
+    permalink: /:collection/:name/
+  tools:
+    output: true
+    permalink: /:collection/:name/
+
+# Exclude from processing
+exclude:
+  - Gemfile
+  - Gemfile.lock
+  - vendor/
+  - .bundle/
+  - .sass-cache/
+  - .jekyll-cache/
+  - gemfiles/
+  - README.md
+
+# Include files
+include:
+  - _pages
+
+# Default front matter
+defaults:
+  - scope:
+      path: ""
+      type: "pages"
+    values:
+      layout: "default"
+  - scope:
+      path: ""
+      type: "posts"
+    values:
+      layout: "post"
+      author: "AI Dev Team"
+
+# Sass/SCSS
+sass:
+  sass_dir: _sass
+  style: compressed
+
+# Permalinks
+permalink: /:year/:month/:day/:title/
+
+# Pagination (using GitHub Pages supported jekyll-paginate)
+paginate: 10
+paginate_path: "/blog/page:num/"
+
+# Repository information (for jekyll-github-metadata)
+repository: cowboylogic/ai-dev
+
+# Slate theme specific settings
+show_downloads: true
+
+# Custom variables
+logo: /assets/images/logo.png
+github_username: cowboylogic
+repo_name: ai-dev


### PR DESCRIPTION
- Add _config.yml with Jekyll site configuration
- Configure Slate theme for professional documentation appearance
- Set up collections for agents and tools documentation
- Enable GitHub Pages compatible plugins (jekyll-remote-theme, jekyll-paginate, etc.)
- Configure repository metadata and custom variables
- Support for both MkDocs and Jekyll deployment options