### PR TITLE
fix(matrix-topology): correct GPT model name from GPT-5.6-Terra to GPT-5.6 Terra

### DIFF
--- a/agents/matrix-topology/AGENTS.md
+++ b/agents/matrix-topology/AGENTS.md
@@ -201,7 +201,7 @@ a new pin is introduced — do not leave retired IDs in the table.
 | `github-copilot/claude-opus-4.8` | `opus` | `Claude Opus 4.8 (copilot)` |
 | `github-copilot/claude-sonnet-5` | `sonnet` | `Claude Sonnet 5 (copilot)` |
 | `github-copilot/claude-haiku-4.5` | `haiku` | `Claude Haiku 4.5 (copilot)` |
-| `github-copilot/gpt-5.6-terra` | `inherit` *(GPT — not available)* | `GPT-5.6-Terra (copilot)` |
+| `github-copilot/gpt-5.6-terra` | `inherit` *(GPT — not available)* | `GPT-5.6 Terra (copilot)` |
 | `github-copilot/gemini-3.1-pro-preview` | `inherit` *(Gemini — not available)* | `Gemini 3.1 Pro (copilot)` |
 
 > [!NOTE]

--- a/agents/matrix-topology/claude/mouse.agent.md
+++ b/agents/matrix-topology/claude/mouse.agent.md
@@ -100,7 +100,7 @@ balanced tier is the right cost/capability trade, not a heavy reasoner. Mouse (G
 also cross-family from Ghost (Gemini), so the express lane's single review gate is
 cross-family with a static assignment — no model switching required.
 
-**Current model:** GPT-5.6-Terra
+**Current model:** GPT-5.6 Terra
 **Family:** OpenAI / GPT
 
 ## Constraints

--- a/agents/matrix-topology/claude/smith.agent.md
+++ b/agents/matrix-topology/claude/smith.agent.md
@@ -70,7 +70,7 @@ cannot change its running model, and Neo cannot override a subagent's model at
 invocation (OpenCode limitation). The cross-family invariant is enforced by Neo's
 **routing**, not by self-switching:
 
-**Model:** GPT-5.6-Terra
+**Model:** GPT-5.6 Terra
 **Family:** OpenAI / GPT
 **Reviews:** Anthropic / Claude (and any Google / xAI) family agents — cross-family
 

--- a/agents/matrix-topology/claude/trinity.agent.md
+++ b/agents/matrix-topology/claude/trinity.agent.md
@@ -92,7 +92,7 @@ Heavy reasoning model — implementation requires understanding the full context
 of specs, tests, and architecture simultaneously, and catching specification gaps
 before they become bugs.
 
-**Current model:** GPT-5.6-Terra
+**Current model:** GPT-5.6 Terra
 **Family:** OpenAI / GPT
 
 ## Constraints

--- a/agents/matrix-topology/copilot/mouse.agent.md
+++ b/agents/matrix-topology/copilot/mouse.agent.md
@@ -6,7 +6,7 @@ description: >
   Mouse does not design, does not write specs, and does not invoke reviewers —
   Neo owns the express review loop.
 tools: ["read", "edit", "run"]
-model: GPT-5.6-Terra (copilot)
+model: GPT-5.6 Terra (copilot)
 user-invocable: false
 ---
 
@@ -100,7 +100,7 @@ balanced tier is the right cost/capability trade, not a heavy reasoner. Mouse (G
 also cross-family from Ghost (Gemini), so the express lane's single review gate is
 cross-family with a static assignment — no model switching required.
 
-**Current model:** GPT-5.6-Terra
+**Current model:** GPT-5.6 Terra
 **Family:** OpenAI / GPT
 
 ## Constraints

--- a/agents/matrix-topology/copilot/smith.agent.md
+++ b/agents/matrix-topology/copilot/smith.agent.md
@@ -5,7 +5,7 @@ description: >
   specifications, and implementation — every time, without exception. Smith finds
   what should not be there.
 tools: ["read", "search"]
-model: GPT-5.6-Terra (copilot)
+model: GPT-5.6 Terra (copilot)
 user-invocable: false
 ---
 
@@ -70,7 +70,7 @@ cannot change its running model, and Neo cannot override a subagent's model at
 invocation (OpenCode limitation). The cross-family invariant is enforced by Neo's
 **routing**, not by self-switching:
 
-**Model:** GPT-5.6-Terra
+**Model:** GPT-5.6 Terra
 **Family:** OpenAI / GPT
 **Reviews:** Anthropic / Claude (and any Google / xAI) family agents — cross-family
 

--- a/agents/matrix-topology/copilot/trinity.agent.md
+++ b/agents/matrix-topology/copilot/trinity.agent.md
@@ -5,7 +5,7 @@ description: >
   is the next step. Trinity does not design, does not write tests — she builds
   what has been designed, precisely, against tests already written.
 tools: ["read", "edit", "run"]
-model: GPT-5.6-Terra (copilot)
+model: GPT-5.6 Terra (copilot)
 user-invocable: false
 ---
 
@@ -92,7 +92,7 @@ Heavy reasoning model — implementation requires understanding the full context
 of specs, tests, and architecture simultaneously, and catching specification gaps
 before they become bugs.
 
-**Current model:** GPT-5.6-Terra
+**Current model:** GPT-5.6 Terra
 **Family:** OpenAI / GPT
 
 ## Constraints

--- a/agents/matrix-topology/opencode/mouse.agent.md
+++ b/agents/matrix-topology/opencode/mouse.agent.md
@@ -105,7 +105,7 @@ balanced tier is the right cost/capability trade, not a heavy reasoner. Mouse (G
 also cross-family from Ghost (Gemini), so the express lane's single review gate is
 cross-family with a static assignment — no model switching required.
 
-**Current model:** GPT-5.6-Terra
+**Current model:** GPT-5.6 Terra
 **Family:** OpenAI / GPT
 
 ## Constraints

--- a/agents/matrix-topology/opencode/smith.agent.md
+++ b/agents/matrix-topology/opencode/smith.agent.md
@@ -74,7 +74,7 @@ cannot change its running model, and Neo cannot override a subagent's model at
 invocation (OpenCode limitation). The cross-family invariant is enforced by Neo's
 **routing**, not by self-switching:
 
-**Model:** GPT-5.6-Terra
+**Model:** GPT-5.6 Terra
 **Family:** OpenAI / GPT
 **Reviews:** Anthropic / Claude (and any Google / xAI) family agents — cross-family
 

--- a/agents/matrix-topology/opencode/trinity.agent.md
+++ b/agents/matrix-topology/opencode/trinity.agent.md
@@ -97,7 +97,7 @@ Heavy reasoning model — implementation requires understanding the full context
 of specs, tests, and architecture simultaneously, and catching specification gaps
 before they become bugs.
 
-**Current model:** GPT-5.6-Terra
+**Current model:** GPT-5.6 Terra
 **Family:** OpenAI / GPT
 
 ## Constraints


### PR DESCRIPTION
## What does this PR do?

The GitHub Copilot display name is **`GPT-5.6 Terra`**, not `GPT-5.6-Terra`. The hyphenated form was used throughout the Matrix Topology — including in the `model:` frontmatter of the three Copilot agents, where it is **not cosmetic**: a model name that does not match the picker does not resolve.

Affects `mouse`, `smith`, and `trinity`.

Found while reconciling the same string in `lane-topology` ([#29](https://github.com/CowboyLogic/ai-dev/pull/29)). Every other model name in this topology already used the spaced form, which is what made the hyphen stand out.

## Type of change

- [ ] New agent definition
- [ ] New or updated skill
- [ ] MCP server configuration
- [ ] Documentation improvement
- [ ] Tool/configuration update
- [ ] Behavioral baseline change
- [x] Bug fix / correction

## Changes made

- `agents/matrix-topology/copilot/{mouse,smith,trinity}.agent.md` — `model:` frontmatter, the load-bearing instance
- `agents/matrix-topology/{opencode,claude,copilot}/{mouse,smith,trinity}` — the `**Current model:**` / `**Model:**` line in each body
- `agents/matrix-topology/AGENTS.md` — the model-name mapping table

Bodies remain character-identical across `opencode/`, `claude/`, and `copilot/`, verified mechanically per this topology's synchronization directive.

## Checklist

- [x] `mkdocs build --strict` passes with no warnings
- [x] All fenced code blocks have a language specifier
- [x] All links resolve correctly
- [x] No hardcoded secrets or tokens
- [x] New pages added to `mkdocs.yml` nav — n/a, no new pages
- [x] New skills follow the `SKILL.md / README.md / QUICKREF.md` structure — n/a
- [x] Related docs updated in this same PR — no `docs/` page references this string for matrix-topology

Markdownlint count is unchanged at 128 pre-existing issues in this tree; none introduced.

## Tested with

Static only — string replacement, three-format body-parity check, `mkdocs build --strict`, and a before/after markdownlint comparison.

> [!NOTE]
> `copilot/ghost.agent.md` pins `Gemini 3.1 Pro (copilot)`. In `lane-topology` the corresponding name was corrected to `Gemini 3.1 Pro (Preview) (copilot)`, which suggests this one may have the same non-resolving problem. Left unchanged — it is a different model and worth confirming against the picker first rather than guessing.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
