### PR TITLE
chore(lane): repin Copilot agent models

### DIFF
--- a/agents/lane-topology/AGENTS.md
+++ b/agents/lane-topology/AGENTS.md
@@ -47,15 +47,15 @@ a bug.
 
 | File | Identifier | Model | Family | Tools | Role |
 |---|---|---|---|---|---|
-| `conductor.md` | `conductor` | `claude-sonnet-5` | Claude | read, task, skill, edit→ledger + `AGENTS.md`/`CLAUDE.md`, bash (scoped: git/gh) | Classify, dispatch, ledger, human interface, shipping |
+| `conductor.md` | `conductor` | `claude-sonnet-4.6` | Claude | read, task, skill, edit→ledger + `AGENTS.md`/`CLAUDE.md`, bash (scoped: git/gh) | Classify, dispatch, ledger, human interface, shipping |
 | `planner.md` | `planner` | `gpt-5.6-sol` | GPT | read, grep, edit→`.agent-output/**` | Socratic planning, design, ADs, requirements |
-| `investigator.md` | `investigator` | `gpt-5.6-sol` | GPT | read, grep, bash, edit→`.agent-output/**` | Read-only comprehension and root cause |
+| `investigator.md` | `investigator` | `gpt-5.6-terra` | GPT | read, grep, bash, edit→`.agent-output/**` | Read-only comprehension and root cause |
 | `builder.md` | `builder` | `gpt-5.6-terra` | GPT | read, edit, bash, grep | Implementation |
-| `mechanic.md` | `mechanic` | `claude-haiku-4.5` | Claude | read, edit, bash | Trivial mechanical edits |
+| `mechanic.md` | `mechanic` | `gpt-5.6-terra` | GPT | read, edit, bash | Trivial mechanical edits |
 | `verifier.md` | `verifier` | `gemini-3.6-flash` | Gemini | read, grep, bash | Cross-family review + independent execution |
 | `adversary.md` | `adversary` | `claude-opus-5` | Claude | read, grep, bash | Security review |
-| `scribe.md` | `scribe` | `claude-sonnet-5` | Claude | read, edit, grep | Documentation |
-| `researcher.md` | `researcher` | `claude-haiku-4.5` | Claude | read, grep, webfetch, websearch, edit→`.agent-output/**` | External research |
+| `scribe.md` | `scribe` | `gpt-5.6-luna` | GPT | read, edit, grep | Documentation |
+| `researcher.md` | `researcher` | `gpt-5.6-luna` | GPT | read, grep, webfetch, websearch, edit→`.agent-output/**` | External research |
 
 `conductor` is `mode: primary`. Everything else is `mode: subagent`.
 
@@ -269,7 +269,9 @@ Only the aliases this roster actually uses:
 | `github-copilot/claude-haiku-4.5` | `Claude Haiku 4.5 (copilot)` |
 | `github-copilot/gpt-5.6-terra` | `GPT-5.6 Terra (copilot)` |
 | `github-copilot/gpt-5.6-sol` | `GPT-5.6 Sol (copilot)` |
+| `github-copilot/gpt-5.6-luna` | `GPT-5.6 Luna (copilot)` |
 | `github-copilot/gemini-3.6-flash` | `Gemini 3.6 Flash (copilot)` |
+| `github-copilot/claude-sonnet-4.6` | `Claude Sonnet 4.6 (copilot)` |
 
 ### Scoped `edit` does not port
 

--- a/agents/lane-topology/AGENTS.md
+++ b/agents/lane-topology/AGENTS.md
@@ -48,7 +48,7 @@ a bug.
 | File | Identifier | Model | Family | Tools | Role |
 |---|---|---|---|---|---|
 | `conductor.md` | `conductor` | `claude-sonnet-5` | Claude | read, task, skill, edit→ledger + `AGENTS.md`/`CLAUDE.md`, bash (scoped: git/gh) | Classify, dispatch, ledger, human interface, shipping |
-| `planner.md` | `planner` | `claude-opus-5` | Claude | read, grep, edit→`.agent-output/**` | Socratic planning, design, ADs, requirements |
+| `planner.md` | `planner` | `gpt-5.6-sol` | GPT | read, grep, edit→`.agent-output/**` | Socratic planning, design, ADs, requirements |
 | `investigator.md` | `investigator` | `gpt-5.6-sol` | GPT | read, grep, bash, edit→`.agent-output/**` | Read-only comprehension and root cause |
 | `builder.md` | `builder` | `gpt-5.6-terra` | GPT | read, edit, bash, grep | Implementation |
 | `mechanic.md` | `mechanic` | `claude-haiku-4.5` | Claude | read, edit, bash | Trivial mechanical edits |

--- a/agents/lane-topology/copilot/adversary.agent.md
+++ b/agents/lane-topology/copilot/adversary.agent.md
@@ -5,7 +5,7 @@ description: >
   whatever lane the work is already in whenever the security band is critical.
   Returns PASS / FIX / ESCALATE with findings by severity.
 tools: ["read", "search", "execute"]
-model: GPT-5.6 Terra (copilot)
+model: Claude Opus 5 (copilot)
 user-invocable: false
 ---
 

--- a/agents/lane-topology/copilot/adversary.agent.md
+++ b/agents/lane-topology/copilot/adversary.agent.md
@@ -5,7 +5,7 @@ description: >
   whatever lane the work is already in whenever the security band is critical.
   Returns PASS / FIX / ESCALATE with findings by severity.
 tools: ["read", "search", "execute"]
-model: Claude Opus 5 (copilot)
+model: GPT-5.6 Terra (copilot)
 user-invocable: false
 ---
 

--- a/agents/lane-topology/copilot/conductor.agent.md
+++ b/agents/lane-topology/copilot/conductor.agent.md
@@ -670,7 +670,7 @@ recommends, and a specific question. Not a status dump — a decision request.
 
 ## Model Selection Rationale
 
-**Current model:** Claude Sonnet 5 · **Family:** Anthropic / Claude
+**Current model:** Claude Sonnet 4.6 · **Family:** Anthropic / Claude
 
 The Conductor is invoked on every turn and holds the longest-lived context in the
 system, so it must be fast and cheap enough to run constantly. Its actual cognitive

--- a/agents/lane-topology/copilot/conductor.agent.md
+++ b/agents/lane-topology/copilot/conductor.agent.md
@@ -6,7 +6,7 @@ description: >
   PASS in a lane that produced a diff, it also commits, pushes, and opens the pull
   request — it never merges.
 tools: ["read", "edit", "agent", "execute"]
-model: Claude Sonnet 5 (copilot)
+model: Claude Sonnet 4.6 (copilot)
 agents:
   - adversary
   - builder

--- a/agents/lane-topology/copilot/investigator.agent.md
+++ b/agents/lane-topology/copilot/investigator.agent.md
@@ -5,7 +5,7 @@ description: >
   modifies the working tree; writes findings only to .agent-output/. The context
   firewall between the codebase and the Conductor.
 tools: ["read", "search", "execute", "edit"]
-model: GPT-5.6 Sol (copilot)
+model: GPT-5.6 Terra (copilot)
 user-invocable: false
 ---
 

--- a/agents/lane-topology/copilot/investigator.agent.md
+++ b/agents/lane-topology/copilot/investigator.agent.md
@@ -131,7 +131,7 @@ Return an escalation instead of findings when:
 
 ## Model Selection Rationale
 
-**Current model:** GPT-5.6 Sol · **Family:** OpenAI / GPT
+**Current model:** GPT-5.6 Terra · **Family:** OpenAI / GPT
 
 Investigation is a long-context problem. The Investigator routinely holds dozens of
 files, full test output, and command history at once, and its quality depends

--- a/agents/lane-topology/copilot/mechanic.agent.md
+++ b/agents/lane-topology/copilot/mechanic.agent.md
@@ -4,7 +4,7 @@ description: >
   comments, log lines, mechanical renames. No logic changes, no control flow, no new
   dependencies. Fast and cheap by design. Stops the moment a change requires thought.
 tools: ["read", "edit", "execute"]
-model: Claude Haiku 4.5 (copilot)
+model: GPT-5.6 Terra (copilot)
 user-invocable: false
 ---
 
@@ -95,7 +95,7 @@ Builder takes it.
 
 ## Model Selection Rationale
 
-**Current model:** Claude Haiku 4.5 · **Family:** Anthropic / Claude
+**Current model:** GPT-5.6 Terra · **Family:** OpenAI / GPT
 
 The cheapest and fastest tier available, which is the entire point. This work is
 high-frequency, low-stakes, and fully specified before the agent starts. The risk of

--- a/agents/lane-topology/copilot/planner.agent.md
+++ b/agents/lane-topology/copilot/planner.agent.md
@@ -5,7 +5,7 @@ description: >
   produces a Plan (PLAN lane) or a Design Brief with Architecture Decisions and
   numbered requirements (BUILD lane). Does not write code.
 tools: ["read", "edit", "search"]
-model: Claude Opus 5 (copilot)
+model: GPT-5.6 Sol (copilot)
 user-invocable: false
 ---
 
@@ -149,9 +149,10 @@ escalates to the human.
 
 ## Model Selection Rationale
 
-**Current model:** Claude Opus 5 · **Family:** Anthropic / Claude
+**Current model:** GPT-5.6 Sol · **Family:** OpenAI / GPT
 
-The heaviest reasoning tier in the topology, and it is justified here specifically:
+The heaviest reasoning tier in the topology, equivalent to Claude Opus 5 in
+reasoning capability but from the GPT family. It is justified here specifically:
 the Planner's output constrains everything downstream, its mistakes are the most
 expensive to discover late, and it runs infrequently — twice per PLAN or BUILD run,
 never in the DIRECT or MECHANICAL lanes. Question quality is the whole product of

--- a/agents/lane-topology/copilot/researcher.agent.md
+++ b/agents/lane-topology/copilot/researcher.agent.md
@@ -4,7 +4,7 @@ description: >
   compatibility, error messages, vendor documentation. Returns findings with sources.
   Does not decide anything and does not touch the codebase.
 tools: ["read", "search", "web", "edit"]
-model: Claude Haiku 4.5 (copilot)
+model: GPT-5.6 Luna (copilot)
 user-invocable: false
 ---
 
@@ -106,7 +106,7 @@ is a different agent's job and the Conductor sequences it.
 
 ## Model Selection Rationale
 
-**Current model:** Claude Haiku 4.5 · **Family:** Anthropic / Claude
+**Current model:** GPT-5.6 Luna · **Family:** OpenAI / GPT
 
 The cheapest tier, matched to the task: retrieval and summarization against sources
 that are already authoritative. There is no synthesis or judgment here — the

--- a/agents/lane-topology/copilot/scribe.agent.md
+++ b/agents/lane-topology/copilot/scribe.agent.md
@@ -4,7 +4,7 @@ description: >
   was supposed to do. Runs at the close of the BUILD lane or on demand. Reads the
   implementation before writing a word about it.
 tools: ["read", "edit", "search"]
-model: Claude Sonnet 5 (copilot)
+model: GPT-5.6 Luna (copilot)
 user-invocable: false
 ---
 
@@ -79,7 +79,7 @@ claims the code does not support. On `FIX`, the Scribe corrects in one cycle.
 
 ## Model Selection Rationale
 
-**Current model:** Claude Sonnet 5 · **Family:** Anthropic / Claude
+**Current model:** GPT-5.6 Luna · **Family:** OpenAI / GPT
 
 Documentation requires accurate comprehension of a full implementation plus the
 judgment to decide what a reader actually needs — real reasoning, but not the heaviest

--- a/agents/lane-topology/opencode/conductor.md
+++ b/agents/lane-topology/opencode/conductor.md
@@ -5,7 +5,7 @@ description: >
   reads source, never produces artifacts, and never reviews. It routes. On a clean
   PASS in a lane that produced a diff, it also commits, pushes, and opens the pull
   request — it never merges.
-model: github-copilot/claude-sonnet-5
+model: github-copilot/claude-sonnet-4.6
 permission:
   read: allow
   edit:
@@ -719,7 +719,7 @@ recommends, and a specific question. Not a status dump — a decision request.
 
 ## Model Selection Rationale
 
-**Current model:** Claude Sonnet 5 · **Family:** Anthropic / Claude
+**Current model:** Claude Sonnet 4.6 · **Family:** Anthropic / Claude
 
 The Conductor is invoked on every turn and holds the longest-lived context in the
 system, so it must be fast and cheap enough to run constantly. Its actual cognitive

--- a/agents/lane-topology/opencode/investigator.md
+++ b/agents/lane-topology/opencode/investigator.md
@@ -4,7 +4,7 @@ description: >
   this work", and "what does this touch". Reads widely, returns compactly. Never
   modifies the working tree; writes findings only to .agent-output/. The context
   firewall between the codebase and the Conductor.
-model: github-copilot/gpt-5.6-sol
+model: github-copilot/gpt-5.6-terra
 permission:
   read: allow
   grep: allow
@@ -152,7 +152,7 @@ Return an escalation instead of findings when:
 
 ## Model Selection Rationale
 
-**Current model:** GPT-5.6 Sol · **Family:** OpenAI / GPT
+**Current model:** GPT-5.6 Terra · **Family:** OpenAI / GPT
 
 Investigation is a long-context problem. The Investigator routinely holds dozens of
 files, full test output, and command history at once, and its quality depends

--- a/agents/lane-topology/opencode/mechanic.md
+++ b/agents/lane-topology/opencode/mechanic.md
@@ -3,7 +3,7 @@ description: >
   Trivial mechanical edits — typos, version bumps, config values, formatting,
   comments, log lines, mechanical renames. No logic changes, no control flow, no new
   dependencies. Fast and cheap by design. Stops the moment a change requires thought.
-model: github-copilot/claude-haiku-4.5
+model: github-copilot/gpt-5.6-terra
 permission:
   read: allow
   edit: allow
@@ -112,7 +112,7 @@ Builder takes it.
 
 ## Model Selection Rationale
 
-**Current model:** Claude Haiku 4.5 · **Family:** Anthropic / Claude
+**Current model:** GPT-5.6 Terra · **Family:** OpenAI / GPT
 
 The cheapest and fastest tier available, which is the entire point. This work is
 high-frequency, low-stakes, and fully specified before the agent starts. The risk of

--- a/agents/lane-topology/opencode/planner.md
+++ b/agents/lane-topology/opencode/planner.md
@@ -4,7 +4,7 @@ description: >
   answering it — returns a QUESTION BRIEF of the decisions that must be made, then
   produces a Plan (PLAN lane) or a Design Brief with Architecture Decisions and
   numbered requirements (BUILD lane). Does not write code.
-model: github-copilot/claude-opus-5
+model: github-copilot/gpt-5.6-sol
 permission:
   read: allow
   grep: allow
@@ -159,9 +159,10 @@ escalates to the human.
 
 ## Model Selection Rationale
 
-**Current model:** Claude Opus 5 · **Family:** Anthropic / Claude
+**Current model:** GPT-5.6 Sol · **Family:** OpenAI / GPT
 
-The heaviest reasoning tier in the topology, and it is justified here specifically:
+The heaviest reasoning tier in the topology, equivalent to Claude Opus 5 in
+reasoning capability but from the GPT family. It is justified here specifically:
 the Planner's output constrains everything downstream, its mistakes are the most
 expensive to discover late, and it runs infrequently — twice per PLAN or BUILD run,
 never in the DIRECT or MECHANICAL lanes. Question quality is the whole product of

--- a/agents/lane-topology/opencode/researcher.md
+++ b/agents/lane-topology/opencode/researcher.md
@@ -3,7 +3,7 @@ description: >
   External information retrieval. Current library APIs, protocol details, version
   compatibility, error messages, vendor documentation. Returns findings with sources.
   Does not decide anything and does not touch the codebase.
-model: github-copilot/claude-haiku-4.5
+model: github-copilot/gpt-5.6-luna
 permission:
   read: allow
   grep: allow
@@ -116,7 +116,7 @@ is a different agent's job and the Conductor sequences it.
 
 ## Model Selection Rationale
 
-**Current model:** Claude Haiku 4.5 · **Family:** Anthropic / Claude
+**Current model:** GPT-5.6 Luna · **Family:** OpenAI / GPT
 
 The cheapest tier, matched to the task: retrieval and summarization against sources
 that are already authoritative. There is no synthesis or judgment here — the

--- a/agents/lane-topology/opencode/scribe.md
+++ b/agents/lane-topology/opencode/scribe.md
@@ -3,7 +3,7 @@ description: >
   Documentation. Writes docs that describe what the code actually does, not what it
   was supposed to do. Runs at the close of the BUILD lane or on demand. Reads the
   implementation before writing a word about it.
-model: github-copilot/claude-sonnet-5
+model: github-copilot/gpt-5.6-luna
 permission:
   read: allow
   edit: allow
@@ -87,7 +87,7 @@ claims the code does not support. On `FIX`, the Scribe corrects in one cycle.
 
 ## Model Selection Rationale
 
-**Current model:** Claude Sonnet 5 · **Family:** Anthropic / Claude
+**Current model:** GPT-5.6 Luna · **Family:** OpenAI / GPT
 
 Documentation requires accurate comprehension of a full implementation plus the
 judgment to decide what a reader actually needs — real reasoning, but not the heaviest

--- a/docs/agents/lane-topology.md
+++ b/docs/agents/lane-topology.md
@@ -62,15 +62,15 @@ findings between agents without re-deriving them.
 
 | Agent | Model | Job | File |
 |---|---|---|---|
-| **Conductor** | Claude Sonnet 5 | Classifies, dispatches, holds the ledger, talks to you. Nothing else. | [conductor](https://github.com/CowboyLogic/ai-dev/blob/main/agents/lane-topology/opencode/conductor.md) |
+| **Conductor** | Claude Sonnet 4.6 | Classifies, dispatches, holds the ledger, talks to you. Nothing else. | [conductor](https://github.com/CowboyLogic/ai-dev/blob/main/agents/lane-topology/opencode/conductor.md) |
 | **Planner** | GPT-5.6 Sol | Socratic planning → design → Architecture Decisions → numbered requirements | [planner](https://github.com/CowboyLogic/ai-dev/blob/main/agents/lane-topology/opencode/planner.md) |
-| **Investigator** | GPT-5.6 Sol | Read-only comprehension and root-cause work | [investigator](https://github.com/CowboyLogic/ai-dev/blob/main/agents/lane-topology/opencode/investigator.md) |
+| **Investigator** | GPT-5.6 Terra | Read-only comprehension and root-cause work | [investigator](https://github.com/CowboyLogic/ai-dev/blob/main/agents/lane-topology/opencode/investigator.md) |
 | **Builder** | GPT-5.6 Terra | Implementation | [builder](https://github.com/CowboyLogic/ai-dev/blob/main/agents/lane-topology/opencode/builder.md) |
-| **Mechanic** | Claude Haiku 4.5 | Trivial mechanical edits | [mechanic](https://github.com/CowboyLogic/ai-dev/blob/main/agents/lane-topology/opencode/mechanic.md) |
+| **Mechanic** | GPT-5.6 Terra | Trivial mechanical edits | [mechanic](https://github.com/CowboyLogic/ai-dev/blob/main/agents/lane-topology/opencode/mechanic.md) |
 | **Verifier** | Gemini 3.6 Flash | Cross-family review **+ runs the tests itself** | [verifier](https://github.com/CowboyLogic/ai-dev/blob/main/agents/lane-topology/opencode/verifier.md) |
 | **Adversary** | Claude Opus 5 | Security review, dispatched by risk band | [adversary](https://github.com/CowboyLogic/ai-dev/blob/main/agents/lane-topology/opencode/adversary.md) |
-| **Scribe** | Claude Sonnet 5 | Documentation | [scribe](https://github.com/CowboyLogic/ai-dev/blob/main/agents/lane-topology/opencode/scribe.md) |
-| **Researcher** | Claude Haiku 4.5 | External research | [researcher](https://github.com/CowboyLogic/ai-dev/blob/main/agents/lane-topology/opencode/researcher.md) |
+| **Scribe** | GPT-5.6 Luna | Documentation | [scribe](https://github.com/CowboyLogic/ai-dev/blob/main/agents/lane-topology/opencode/scribe.md) |
+| **Researcher** | GPT-5.6 Luna | External research | [researcher](https://github.com/CowboyLogic/ai-dev/blob/main/agents/lane-topology/opencode/researcher.md) |
 
 The Conductor is the only agent you talk to and the only one with dispatch
 authority (`mode: primary`); the other eight are subagents it routes work to. It

--- a/docs/agents/lane-topology.md
+++ b/docs/agents/lane-topology.md
@@ -63,7 +63,7 @@ findings between agents without re-deriving them.
 | Agent | Model | Job | File |
 |---|---|---|---|
 | **Conductor** | Claude Sonnet 5 | Classifies, dispatches, holds the ledger, talks to you. Nothing else. | [conductor](https://github.com/CowboyLogic/ai-dev/blob/main/agents/lane-topology/opencode/conductor.md) |
-| **Planner** | Claude Opus 5 | Socratic planning → design → Architecture Decisions → numbered requirements | [planner](https://github.com/CowboyLogic/ai-dev/blob/main/agents/lane-topology/opencode/planner.md) |
+| **Planner** | GPT-5.6 Sol | Socratic planning → design → Architecture Decisions → numbered requirements | [planner](https://github.com/CowboyLogic/ai-dev/blob/main/agents/lane-topology/opencode/planner.md) |
 | **Investigator** | GPT-5.6 Sol | Read-only comprehension and root-cause work | [investigator](https://github.com/CowboyLogic/ai-dev/blob/main/agents/lane-topology/opencode/investigator.md) |
 | **Builder** | GPT-5.6 Terra | Implementation | [builder](https://github.com/CowboyLogic/ai-dev/blob/main/agents/lane-topology/opencode/builder.md) |
 | **Mechanic** | Claude Haiku 4.5 | Trivial mechanical edits | [mechanic](https://github.com/CowboyLogic/ai-dev/blob/main/agents/lane-topology/opencode/mechanic.md) |


### PR DESCRIPTION
## What does this PR do?

Repins the Lane Topology Planner from Claude Opus 5 to the equivalent GPT-5.6 Sol tier and updates the requested Copilot agent model selections.

## Type of change

- [ ] New agent definition
- [ ] New or updated skill
- [ ] MCP server configuration
- [ ] Documentation improvement
- [x] Tool/configuration update
- [x] Behavioral baseline change
- [ ] Bug fix / correction
- [ ] Other

## Changes made

- Updates the six reconstructed Copilot model pins and their model-selection rationale.
- Repins the canonical OpenCode and Copilot Planner definitions to GPT-5.6 Sol.
- Synchronizes the Planner rationale, lane-topology roster, and published documentation.

## Checklist

- [x] `mkdocs build --strict` passes with no build errors
- [x] All fenced code blocks have a language specifier
- [x] All links resolve correctly
- [x] No hardcoded secrets or tokens
- [ ] New pages added to `mkdocs.yml` nav
- [ ] New skills follow the `SKILL.md / README.md / QUICKREF.md` structure
- [x] Related docs updated in this same PR

## Tested with

- `mkdocs build --strict` passed; it emitted the existing Material warning and existing `tools/callouts.md` unnaved-page notice.
- `python3 agents/lane-topology/validate.py` reports 6 existing topology discrepancies in the six reconstructed Copilot model changes: three body-parity failures and three frontmatter/rationale mismatches. `git diff --check` passes.