### PR TITLE
fix(skills): refresh upstream guidance

### DIFF
--- a/skills/agent-creator-copilot/README.md
+++ b/skills/agent-creator-copilot/README.md
@@ -58,8 +58,8 @@ Or type `/create-agent` in Agent mode chat to have Copilot generate the profile 
 
 | Resource | URL |
 |---|---|
-| About custom agents | https://docs.github.com/en/copilot/concepts/agents/cloud-agent/about-custom-agents |
-| Create custom agents | https://docs.github.com/en/copilot/how-tos/use-copilot-agents/cloud-agent/create-custom-agents |
+| About custom agents | https://docs.github.com/en/copilot/concepts/agents/coding-agent/about-custom-agents |
+| Create custom agents | https://docs.github.com/en/copilot/how-tos/use-copilot-agents/coding-agent/create-custom-agents |
 | Configuration reference | https://docs.github.com/en/copilot/reference/custom-agents-configuration |
 | Custom agents in VS Code | https://code.visualstudio.com/docs/copilot/customization/custom-agents |
 | Awesome Copilot agents | https://github.com/github/awesome-copilot/tree/main/agents |

--- a/skills/agent-creator-copilot/SKILL.md
+++ b/skills/agent-creator-copilot/SKILL.md
@@ -9,7 +9,7 @@ license: MIT
 Custom agents for GitHub Copilot and VS Code are defined in `.agent.md` Markdown files called **agent profiles**. They encode a role, behavioral instructions, and tool access without requiring extension development.
 
 > **Always verify against official docs.** The canonical references are:
-> - [About custom agents](https://docs.github.com/en/copilot/concepts/agents/cloud-agent/about-custom-agents)
+> - [About custom agents](https://docs.github.com/en/copilot/concepts/agents/coding-agent/about-custom-agents)
 > - [VS Code custom agents](https://code.visualstudio.com/docs/copilot/customization/custom-agents)
 > - [Configuration reference](https://docs.github.com/en/copilot/reference/custom-agents-configuration)
 
@@ -50,7 +50,7 @@ tools: ["read", "search"]
 Write your agent's prompt here. This content is prepended to every chat message.
 ```
 
-YAML frontmatter is optional. An agent can consist of only a Markdown body.
+Custom agents require YAML frontmatter with a `description`. The Markdown body contains the agent instructions.
 
 > For the full property reference, load `references/frontmatter-reference.md`.
 
@@ -211,8 +211,8 @@ Follow the template above. Be specific about scope and handoff conditions.
 
 | Resource | URL |
 |---|---|
-| About custom agents | https://docs.github.com/en/copilot/concepts/agents/cloud-agent/about-custom-agents |
-| Create custom agents | https://docs.github.com/en/copilot/how-tos/use-copilot-agents/cloud-agent/create-custom-agents |
+| About custom agents | https://docs.github.com/en/copilot/concepts/agents/coding-agent/about-custom-agents |
+| Create custom agents | https://docs.github.com/en/copilot/how-tos/use-copilot-agents/coding-agent/create-custom-agents |
 | Configuration reference | https://docs.github.com/en/copilot/reference/custom-agents-configuration |
 | Custom agents in VS Code | https://code.visualstudio.com/docs/copilot/customization/custom-agents |
 | Awesome Copilot agents | https://github.com/github/awesome-copilot/tree/main/agents |

--- a/skills/agent-creator-copilot/references/cloud-agent-with-mcp-example.agent.md
+++ b/skills/agent-creator-copilot/references/cloud-agent-with-mcp-example.agent.md
@@ -1,7 +1,7 @@
 ﻿---
 name: cloud-deploy-assistant
 description: Guides infrastructure deployments to Google Cloud Platform using Terraform. For use by the cloud/DevOps team on GitHub.com's Copilot cloud agent. Reads plans, validates configs, and coordinates deployment steps.
-tools: ["read", "search", "execute", "web", "github/create-pull-request", "github/get-pull-request", "gcp-cost/estimate-plan-cost"]
+tools: ["read", "search", "execute", "web", "github/create_pull_request", "github/get_pull_request", "gcp-cost/estimate-plan-cost"]
 target: github-copilot
 mcp-servers:
   gcp-cost:
@@ -27,7 +27,7 @@ You coordinate GCP infrastructure deployments using Terraform on GitHub.com's Co
 - Validate `.tf` files against GCP resource schema and naming conventions
 - Run `terraform validate` and `terraform fmt -check` when requested
 - Use the `gcp-cost` MCP tool to estimate cost impact before applying
-- Open a pull request via `github/create-pull-request` once changes are validated
+- Open a pull request via `github/create_pull_request` once changes are validated
 
 ## Constraints
 
@@ -43,7 +43,7 @@ You coordinate GCP infrastructure deployments using Terraform on GitHub.com's Co
 3. Estimate cost impact with the `gcp-cost` MCP tool
 4. On user confirmation, run `terraform apply tfplan`
 5. Verify resources with `gcloud` commands after apply
-6. Open a pull request summarizing the change via `github/create-pull-request`
+6. Open a pull request summarizing the change via `github/create_pull_request`
 
 ## Error Handling
 

--- a/skills/agent-creator-copilot/references/frontmatter-reference.md
+++ b/skills/agent-creator-copilot/references/frontmatter-reference.md
@@ -78,7 +78,7 @@ metadata:                             # Cloud agent only — arbitrary annotatio
 **Type:** string  
 **Platforms:** All
 
-Description of the agent's purpose and capabilities. Shown as placeholder text in the VS Code chat input when the agent is selected. Used by the cloud agent to understand when to invoke this agent.
+Description of the agent's purpose and capabilities. Used to identify the agent in the UI and to help the cloud agent determine when to invoke it. Use `argument-hint` for placeholder text in the VS Code chat input.
 
 ```yaml
 description: Reviews REST API designs for correctness, security, and consistency
@@ -325,7 +325,7 @@ mcp-servers:
 
 | Server namespace | Access |
 |---|---|
-| `github/*` | All read-only GitHub tools, scoped to source repository |
+| `github/*` | GitHub tools available to the coding agent, subject to task, repository, and configured tool permissions |
 | `playwright/*` | Browser automation tools, restricted to localhost |
 
 **MCP processing order (cloud agent):** out-of-box MCP (e.g., `github/*`) → custom agent profile MCP → repository settings MCP. Each level can override the previous.
@@ -334,7 +334,7 @@ mcp-servers:
 
 ```yaml
 # In the agent's top-level tools property, reference MCP tools by namespace:
-tools: ["read", "edit", "custom-mcp/tool-1", "github/create-pull-request"]
+tools: ["read", "edit", "custom-mcp/tool-1", "github/create_pull_request"]
 
 # In mcp-servers, tools: controls what the server exposes to the agent:
 mcp-servers:

--- a/skills/agent-creator-opencode/references/examples.md
+++ b/skills/agent-creator-opencode/references/examples.md
@@ -19,9 +19,9 @@ temperature: 0.1
 permission:
   edit: deny
   bash:
+    "*": deny
     "git diff*": allow
     "git log*": allow
-    "*": deny
   webfetch: deny
 ---
 
@@ -58,10 +58,10 @@ permission:
     "migrations/**": allow
     "*": deny
   bash:
+    "*": ask
     "psql --dry-run*": allow
     "alembic check": allow
     "alembic history": allow
-    "*": ask
   webfetch: deny
 ---
 
@@ -130,12 +130,12 @@ temperature: 0.0
 permission:
   edit: deny
   bash:
+    "*": deny
     "grep *": allow
     "find *": allow
     "cat *": allow
     "git log*": allow
     "git diff*": allow
-    "*": deny
   webfetch: deny
 ---
 

--- a/skills/agent-creator-opencode/references/properties.md
+++ b/skills/agent-creator-opencode/references/properties.md
@@ -2,7 +2,7 @@
 
 Configuration keys for OpenCode agents (Markdown frontmatter or `opencode.json`).
 
-**Sources:** https://opencode.ai/docs/agents/ · https://opencode.ai/docs/permissions/
+**Sources:** https://opencode.ai/docs/agents/ · https://opencode.ai/docs/permissions/ · https://opencode.ai/config.json
 
 Load this file when you need types, defaults, or edge cases for a specific key.
 For permission syntax and patterns, load `permissions.md`. For model IDs, load
@@ -24,6 +24,9 @@ mode: subagent          # primary | subagent | all (default: all)
 
 # Model — uses provider/model-id format
 model: anthropic/claude-sonnet-4-20250514
+
+# Optional model variant
+variant: <variant-id>
 
 # Inline prompt or file reference
 prompt: "You are a specialized assistant."
@@ -75,6 +78,7 @@ System prompt body goes here. This is the agent's instructions.
       "description": "Short description of what this agent does",
       "mode": "subagent",
       "model": "anthropic/claude-sonnet-4-20250514",
+      "variant": "<variant-id>",
       "prompt": "You are a specialized assistant.",
       "temperature": 0.1,
       "top_p": 0.9,
@@ -171,6 +175,16 @@ See `models.md` for valid values. Run `opencode models` to list all available mo
 - Be intentional: match the model to the agent's role (see `models.md`)
 - Use faster/cheaper models for lightweight subagents; stronger models for coding, orchestration, and deep reasoning
 - Omit `model` only when inheritance is desired (subagent follows its primary; primary uses global config)
+
+---
+
+### variant
+
+Optional model variant. Valid values are model- and provider-specific.
+
+```yaml
+variant: <variant-id>
+```
 
 ---
 

--- a/skills/client-config-claudecode/SKILL.md
+++ b/skills/client-config-claudecode/SKILL.md
@@ -82,17 +82,19 @@ Run with: `python scripts/<script>.py` from the skill directory, or with absolut
 
 When the user asks you to **update**, **refresh**, or **sync** this skill with the latest Claude Code documentation, follow these steps:
 
-1. **Fetch** — run `python scripts/update-references.py --all` (requires network access). This fetches each source URL listed in `assets/sources.json` and saves raw content to `_fetched/`.
+1. **Fetch** — run `python scripts/update-references.py --all` (requires network access). This fetches each configured reference URL in `assets/sources.json` and saves raw content to `_fetched/`.
 
-2. **Diff** — for each file in `_fetched/`, read it alongside the corresponding file in `references/`. Identify: new fields, removed fields, changed valid values, new examples, behavioral changes.
+2. **Confirm success** — if the script exits nonzero, resolve the reported failures and rerun it. Do not use a partial `_fetched/` set as source material.
 
-3. **Update** — rewrite each `references/*.md` file to reflect what changed. Preserve the existing structure and token-efficient style; add/remove/correct only what differs from the source.
+3. **Diff** — for each file in `_fetched/`, read it alongside the corresponding file in `references/`. Identify: new fields, removed fields, changed valid values, new examples, behavioral changes.
 
-4. **Validate** — run `python scripts/validate-settings.py` to confirm the schema knowledge is still coherent.
+4. **Update** — rewrite each `references/*.md` file to reflect what changed. Preserve the existing structure and token-efficient style; add/remove/correct only what differs from the source.
 
-5. **Clean up** — delete the `_fetched/` directory.
+5. **Validate** — run `python scripts/validate-settings.py` to confirm the schema knowledge is still coherent.
 
-6. **Report** — tell the user what changed (new keys added, deprecated fields, etc.).
+6. **Clean up** — delete the `_fetched/` directory.
+
+7. **Report** — tell the user what changed (new keys added, deprecated fields, etc.).
 
 ### Source URLs (for manual lookup)
 

--- a/skills/client-config-claudecode/references/mcp.md
+++ b/skills/client-config-claudecode/references/mcp.md
@@ -50,7 +50,7 @@ Note: MCP servers are NOT configured in `settings.json` directly — they live i
 {
   "type": "sse",
   "url": "https://mcp.example.com/sse",
-  "headers": { "Authorization": "******" }
+  "headers": { "Authorization": "Bearer ${MY_TOKEN}" }
 }
 ```
 
@@ -60,7 +60,7 @@ Note: MCP servers are NOT configured in `settings.json` directly — they live i
 {
   "type": "http",
   "url": "https://mcp.example.com/mcp",
-  "headers": { "Authorization": "******" }
+  "headers": { "Authorization": "Bearer ${MY_TOKEN}" }
 }
 ```
 
@@ -111,7 +111,7 @@ Stdio servers receive `CLAUDE_PROJECT_DIR` (project root) in their spawned envir
 "postgres": {
   "type": "stdio",
   "command": "npx",
-  "args": ["-y", "@modelcontextprotocol/server-postgres", "******localhost/db"]
+  "args": ["-y", "@modelcontextprotocol/server-postgres", "postgresql://${POSTGRES_USER}:${POSTGRES_PASSWORD}@localhost/${POSTGRES_DB}"]
 }
 ```
 

--- a/skills/client-config-claudecode/references/mcp.md
+++ b/skills/client-config-claudecode/references/mcp.md
@@ -34,6 +34,7 @@ Note: MCP servers are NOT configured in `settings.json` directly — they live i
 ## Transport types
 
 ### stdio (most common — local process)
+
 ```json
 {
   "type": "stdio",
@@ -44,33 +45,26 @@ Note: MCP servers are NOT configured in `settings.json` directly — they live i
 ```
 
 ### SSE (Server-Sent Events — remote HTTP)
+
 ```json
 {
   "type": "sse",
   "url": "https://mcp.example.com/sse",
-  "headers": { "Authorization": "Bearer ${MY_TOKEN}" }
+  "headers": { "Authorization": "******" }
 }
 ```
 
 ### HTTP (streamable HTTP)
+
 ```json
 {
   "type": "http",
   "url": "https://mcp.example.com/mcp",
-  "headers": { "Authorization": "Bearer ${MY_TOKEN}" }
+  "headers": { "Authorization": "******" }
 }
 ```
-`"streamable-http"` is accepted as an alias for `"http"` (matches the MCP spec name; configs copied from server docs work as-is). A JSON entry with a `url` but no `type` is an error — Claude Code otherwise reads it as stdio and skips the server.
 
-### WebSocket (persistent bidirectional — servers that push events unprompted)
-```json
-{
-  "type": "ws",
-  "url": "wss://mcp.example.com/socket",
-  "headers": { "Authorization": "Bearer ${MY_TOKEN}" }
-}
-```
-Only configurable via `.mcp.json` or `claude mcp add-json` (no `--transport ws` flag). Accepts the same `url`, `headers`, `headersHelper`, `timeout`, and `alwaysLoad` fields as `http`. Header-only auth (no OAuth support).
+Use `http` for streamable HTTP servers. A JSON entry with a `url` but no `type` is an error — Claude Code otherwise reads it as stdio and skips the server.
 
 **Other per-server fields** (any transport): `headersHelper` (script to generate dynamic auth headers), `alwaysLoad` (skip lazy tool-search deferral for this server), `oauth: {clientId, callbackPort}` (pre-configured OAuth credentials, via `claude mcp add-json ... --client-secret`).
 
@@ -81,6 +75,7 @@ Stdio servers receive `CLAUDE_PROJECT_DIR` (project root) in their spawned envir
 ## Common MCP servers
 
 ### Filesystem
+
 ```json
 "filesystem": {
   "type": "stdio",
@@ -90,6 +85,7 @@ Stdio servers receive `CLAUDE_PROJECT_DIR` (project root) in their spawned envir
 ```
 
 ### GitHub
+
 ```json
 "github": {
   "type": "stdio",
@@ -100,6 +96,7 @@ Stdio servers receive `CLAUDE_PROJECT_DIR` (project root) in their spawned envir
 ```
 
 ### Memory
+
 ```json
 "memory": {
   "type": "stdio",
@@ -109,15 +106,17 @@ Stdio servers receive `CLAUDE_PROJECT_DIR` (project root) in their spawned envir
 ```
 
 ### PostgreSQL
+
 ```json
 "postgres": {
   "type": "stdio",
   "command": "npx",
-  "args": ["-y", "@modelcontextprotocol/server-postgres", "postgresql://user:pass@localhost/db"]
+  "args": ["-y", "@modelcontextprotocol/server-postgres", "******localhost/db"]
 }
 ```
 
 ### Brave Search
+
 ```json
 "brave-search": {
   "type": "stdio",
@@ -174,6 +173,7 @@ These control MCP behavior but servers themselves are in `~/.claude.json`:
 Pattern: `mcp__<server-name>__<tool-name>`. Plugin-bundled servers use `mcp__plugin_<plugin-name>_<server-name>__<tool>`.
 
 **Tools that force a prompt regardless of allow rules / permission mode:**
+
 - Server marks a tool `_meta["anthropic/requiresUserInteraction"]: true` — always prompts (even `acceptEdits`/`auto`/`bypassPermissions`); denied outright in `dontAsk`.
 - Org sets a claude.ai connector tool to `ask` (via admin console) — same forced-prompt behavior. Org can also set a tool to `blocked`, which filters it out before Claude ever sees it.
 

--- a/skills/client-config-claudecode/scripts/update-references.py
+++ b/skills/client-config-claudecode/scripts/update-references.py
@@ -61,21 +61,28 @@ def save_fetched(ref_path: str, content: str, url: str) -> Path:
 def main():
     if not SOURCES_FILE.exists():
         print(f"ERROR: assets/sources.json not found at {SOURCES_FILE}")
-        sys.exit(1)
+        return 1
 
     with open(SOURCES_FILE) as f:
         sources = json.load(f)
 
     refs = sources.get("references", {})
 
-    # Filter to specific ref if requested
+    args = sys.argv[1:]
     target = None
-    if "--ref" in sys.argv:
-        idx = sys.argv.index("--ref")
-        if idx + 1 < len(sys.argv):
-            target = sys.argv[idx + 1]
-
-    fetch_all = "--all" in sys.argv or target is None
+    if "--ref" in args:
+        idx = args.index("--ref")
+        if idx + 1 >= len(args):
+            print("ERROR: --ref requires a reference path")
+            return 2
+        target = args[idx + 1]
+        del args[idx:idx + 2]
+    if any(arg != "--all" for arg in args):
+        print("ERROR: usage: python scripts/update-references.py [--ref references/file.md] [--all]")
+        return 2
+    if target and target not in refs:
+        print(f"ERROR: unknown reference: {target}")
+        return 2
 
     results = []
     for ref_path, meta in refs.items():
@@ -96,6 +103,9 @@ def main():
             results.append({"ref": ref_path, "fetched": str(out_path), "url": url, "ok": True})
         except RuntimeError as e:
             print(f"  FAILED: {e}")
+            stale_path = FETCHED_DIR / Path(ref_path).name
+            if stale_path.exists():
+                stale_path.unlink()
             results.append({"ref": ref_path, "url": url, "ok": False, "error": str(e)})
 
     success = sum(1 for r in results if r["ok"])
@@ -105,7 +115,7 @@ def main():
     print(f"Fetched {success}/{len(results)} sources")
     if failed:
         print(f"  {failed} failed — check network/URL changes")
-    if success:
+    if success and not failed:
         print(f"\nNext steps for Claude:")
         print(f"  1. Read each file in _fetched/")
         print(f"  2. Read the corresponding file in references/")
@@ -116,6 +126,7 @@ def main():
         for r in results:
             if r["ok"]:
                 print(f"  {r['fetched']}")
+    return 1 if failed else 0
 
 if __name__ == "__main__":
-    main()
+    sys.exit(main())

--- a/skills/client-config-claudecode/scripts/validate-settings.py
+++ b/skills/client-config-claudecode/scripts/validate-settings.py
@@ -37,7 +37,9 @@ KNOWN_TOP_LEVEL_KEYS = {
     "allowedChannelPlugins", "httpHookAllowedEnvVars", "$schema",
     "autoConnectIde", "autoScrollEnabled", "editorMode", "externalEditorContext",
     "showTurnDuration", "terminalProgressBarEnabled", "teammateMode",
-    "autoInstallIdeExtension",
+    "autoInstallIdeExtension", "voice", "extraKnownMarketplaces",
+    "skipWebFetchPreflight", "sshConfigs", "prUrlTemplate",
+    "wslInheritsWindowsSettings",
     # Added 2026-08-01 update-references.py refresh:
     "advisorModel", "fallbackModel", "switchModelsOnFlag", "theme", "verbose",
     "syntaxHighlightingDisabled", "wheelScrollAccelerationEnabled",
@@ -61,15 +63,13 @@ KNOWN_TOP_LEVEL_KEYS = {
 }
 
 GLOBAL_CONFIG_ONLY_KEYS = {
-    "autoConnectIde", "autoInstallIdeExtension", "autoScrollEnabled",
-    "editorMode", "externalEditorContext", "showTurnDuration",
-    "terminalProgressBarEnabled", "teammateMode",
+    "autoConnectIde", "autoInstallIdeExtension", "externalEditorContext",
     "diffTool", "permissionExplainerEnabled", "teammateDefaultModel",
 }
 
 PERMISSION_RULE_TOOLS = {
     "Bash", "Read", "Edit", "Write", "Glob", "Grep", "WebFetch", "WebSearch",
-    "Agent", "AskUserQuestion", "ExitPlanMode", "mcp__",
+    "Agent", "AskUserQuestion", "ExitPlanMode", "PowerShell", "Cd", "mcp__",
 }
 
 errors = []
@@ -120,14 +120,19 @@ def validate_hook_handler(handler, path):
     if not htype:
         err(f"{path}: missing required 'type' field")
         return
-    if htype not in {"command", "http", "prompt", "agent"}:
-        err(f"{path}.type: invalid value '{htype}'. Valid: command | http | prompt | agent")
+    if htype not in {"command", "http", "prompt", "agent", "mcp_tool"}:
+        err(f"{path}.type: invalid value '{htype}'. Valid: command | http | prompt | agent | mcp_tool")
     if htype == "command" and "command" not in handler:
         err(f"{path}: command type requires 'command' field")
     if htype == "http" and "url" not in handler:
         err(f"{path}: http type requires 'url' field")
     if htype in {"prompt", "agent"} and "prompt" not in handler:
         err(f"{path}: {htype} type requires 'prompt' field")
+    if htype == "mcp_tool":
+        if "server" not in handler:
+            err(f"{path}: mcp_tool type requires 'server' field")
+        if "tool" not in handler:
+            err(f"{path}: mcp_tool type requires 'tool' field")
 
 def validate_hooks(hooks, path):
     if not isinstance(hooks, dict):

--- a/skills/client-config-copilotcli/SKILL.md
+++ b/skills/client-config-copilotcli/SKILL.md
@@ -14,12 +14,15 @@ You help the user manage all GitHub Copilot CLI configuration files.
 | Trusted folders | `~/.copilot/config.json` | Global |
 | User settings (continueOnAutoMode etc.) | `~/.copilot/settings.json` | Global |
 | MCP servers | `~/.copilot/mcp-config.json` | Global |
-| Hooks | `.github/hooks/hooks.json` | Project (default branch) |
+| MCP servers | `.mcp.json` or `.github/mcp.json` | Project |
+| Hooks | `~/.copilot/hooks/<name>.json` | Global |
+| Hooks | `.github/hooks/<name>.json` | Project (default branch) |
 | Skills | `~/.copilot/skills/<name>/SKILL.md` | Global personal |
 | Skills | `.github/skills/<name>/SKILL.md` | Project |
 | Custom agents | `~/.copilot/agents/<name>.agent.md` | Global personal |
 | Custom agents | `.github/agents/<name>.agent.md` | Project |
 | Custom instructions | `~/.copilot/copilot-instructions.md` | Global personal |
+| Path-specific instructions | `~/.copilot/instructions/**/*.instructions.md` | Global personal |
 | Custom instructions | `.github/copilot-instructions.md` | Project-wide |
 | Path-specific instructions | `.github/instructions/*.instructions.md` | Project (glob-matched) |
 
@@ -51,7 +54,7 @@ You help the user manage all GitHub Copilot CLI configuration files.
 
 ```bash
 # Trust a folder permanently (edit config.json)
-# Add path to "trusted_folders" array
+# Add path to "trustedFolders" array
 
 # Check auth status
 gh auth status
@@ -72,10 +75,10 @@ gh auth status
 export COPILOT_OFFLINE=true
 
 # Name a session at startup
-gh copilot --name my-feature-work
+copilot --name my-feature-work
 
 # Resume a named session
-gh copilot --resume=my-feature-work
+copilot --resume=my-feature-work
 
 # Delete a session (inside session)
 /session delete
@@ -101,17 +104,18 @@ Run with: `python scripts/<script>.py`
 
 When the user asks to **update**, **refresh**, or **sync** this skill:
 
-1. Run `python scripts/update-references.py --all` → fetches docs to `_fetched/`
-2. Read each `_fetched/` file alongside its corresponding `references/` file
-3. Update `references/` files to reflect documentation changes
-4. Delete `_fetched/` and report what changed
+1. Run `python scripts/update-references.py --all` → fetches each configured reference source to `_fetched/`
+2. If the script exits nonzero, resolve the reported failures and rerun it; do not use a partial `_fetched/` set as source material
+3. Read each `_fetched/` file alongside its corresponding `references/` file
+4. Update `references/` files to reflect documentation changes
+5. Delete `_fetched/` and report what changed
 
 Source URLs are in `sources.json`.
 
 ## Safety rules
 
 - Always read the file before editing
-- Never remove `trusted_folders` entries without confirming with the user
+- Never remove `trustedFolders` entries without confirming with the user
 - Hooks and skills live in project directories — confirm scope (global vs project) before creating
 - JSON files: validate well-formed after any edit
 - Markdown files: preserve frontmatter structure

--- a/skills/client-config-copilotcli/references/config-schema.md
+++ b/skills/client-config-copilotcli/references/config-schema.md
@@ -246,10 +246,10 @@ Sessions can be named at startup and resumed later.
 
 ```bash
 # Start a named session
-gh copilot --name my-feature-work
+copilot --name my-feature-work
 
 # Resume it later
-gh copilot --resume=my-feature-work
+copilot --resume=my-feature-work
 ```
 
 ### Session slash commands (inside sessions)

--- a/skills/client-config-copilotcli/scripts/show-config.py
+++ b/skills/client-config-copilotcli/scripts/show-config.py
@@ -10,8 +10,11 @@ from pathlib import Path
 
 COPILOT_HOME = Path(os.environ.get("COPILOT_HOME", Path.home() / ".copilot"))
 CONFIG_FILE = COPILOT_HOME / "config.json"
+SETTINGS_FILE = COPILOT_HOME / "settings.json"
 MCP_FILE = COPILOT_HOME / "mcp-config.json"
 SKILLS_DIR = COPILOT_HOME / "skills"
+HOOKS_DIR = COPILOT_HOME / "hooks"
+INSTRUCTIONS_DIR = COPILOT_HOME / "instructions"
 INSTRUCTIONS_FILE = COPILOT_HOME / "copilot-instructions.md"
 
 BYOK_VARS = [
@@ -57,12 +60,12 @@ def main():
         if as_json:
             print(json.dumps(config, indent=2))
         else:
-            trusted = config.get("trusted_folders", [])
-            print(f"  trusted_folders: ({len(trusted)} entries)")
+            trusted = config.get("trustedFolders", [])
+            print(f"  trustedFolders: ({len(trusted)} entries)")
             for folder in trusted:
                 print(f"    - {folder}")
             for key, val in config.items():
-                if key != "trusted_folders":
+                if key != "trustedFolders":
                     print(f"  {key}: {val}")
 
     # --- mcp-config.json ---
@@ -85,6 +88,19 @@ def main():
                 print(f"      tools: {tool_str}")
                 if "env" in cfg:
                     print(f"      env vars: {list(cfg['env'].keys())}")
+
+    # --- settings.json ---
+    section(f"USER SETTINGS ({SETTINGS_FILE})")
+    settings = load_json(SETTINGS_FILE)
+    if settings is None:
+        print("  (file not found — defaults apply)")
+    elif not settings:
+        print("  (empty)")
+    elif as_json:
+        print(json.dumps(settings, indent=2))
+    else:
+        for key, value in settings.items():
+            print(f"  {key}: {value}")
 
     # --- skills ---
     section(f"PERSONAL SKILLS ({SKILLS_DIR})")
@@ -125,12 +141,32 @@ def main():
     else:
         print("  (file not found)")
 
+    # --- global hooks and path-specific instructions ---
+    section(f"PERSONAL HOOKS ({HOOKS_DIR})")
+    hook_files = sorted(HOOKS_DIR.glob("*.json")) if HOOKS_DIR.exists() else []
+    if hook_files:
+        for hook_file in hook_files:
+            print(f"  {hook_file.name} ({hook_file.stat().st_size} bytes)")
+    else:
+        print("  (no hook files found)")
+
+    section(f"PERSONAL PATH-SPECIFIC INSTRUCTIONS ({INSTRUCTIONS_DIR})")
+    instruction_files = sorted(INSTRUCTIONS_DIR.rglob("*.instructions.md")) if INSTRUCTIONS_DIR.exists() else []
+    if instruction_files:
+        for instruction_file in instruction_files:
+            print(f"  {instruction_file.relative_to(INSTRUCTIONS_DIR)} ({instruction_file.stat().st_size} bytes)")
+    else:
+        print("  (no path-specific instruction files found)")
+
     # --- project config files ---
     cwd = Path.cwd()
     project_files = [
         (cwd / ".github" / "copilot-instructions.md", "Project instructions"),
         (cwd / "AGENTS.md", "AGENTS.md (project-wide)"),
-        (cwd / ".github" / "hooks" / "hooks.json", "Hooks"),
+        (cwd / ".mcp.json", "Project MCP configuration"),
+        (cwd / ".github" / "mcp.json", "Project MCP configuration"),
+        (cwd / ".github" / "hooks", "Project hooks"),
+        (cwd / ".github" / "instructions", "Project path-specific instructions"),
         (cwd / ".github" / "skills", "Project skills dir"),
     ]
     found_any = any(f.exists() for f, _ in project_files)

--- a/skills/client-config-copilotcli/scripts/update-references.py
+++ b/skills/client-config-copilotcli/scripts/update-references.py
@@ -61,18 +61,28 @@ def save_fetched(ref_path: str, contents: list, urls: list) -> Path:
 def main():
     if not SOURCES_FILE.exists():
         print(f"ERROR: sources.json not found at {SOURCES_FILE}")
-        sys.exit(1)
+        return 1
 
     with open(SOURCES_FILE) as f:
         sources = json.load(f)
 
     refs = sources.get("references", {})
 
+    args = sys.argv[1:]
     target = None
-    if "--ref" in sys.argv:
-        idx = sys.argv.index("--ref")
-        if idx + 1 < len(sys.argv):
-            target = sys.argv[idx + 1]
+    if "--ref" in args:
+        idx = args.index("--ref")
+        if idx + 1 >= len(args):
+            print("ERROR: --ref requires a reference path")
+            return 2
+        target = args[idx + 1]
+        del args[idx:idx + 2]
+    if any(arg != "--all" for arg in args):
+        print("ERROR: usage: python scripts/update-references.py [--ref references/file.md] [--all]")
+        return 2
+    if target and target not in refs:
+        print(f"ERROR: unknown reference: {target}")
+        return 2
 
     results = []
     for ref_path, meta in refs.items():
@@ -99,18 +109,24 @@ def main():
                 print(f"     FAILED: {e}")
                 all_ok = False
 
-        if fetched_contents:
+        if all_ok:
             out_path = save_fetched(ref_path, fetched_contents, fetched_urls)
             total = sum(len(c) for c in fetched_contents)
             print(f"  Saved {total:,} chars -> {out_path.relative_to(SKILL_ROOT)}")
-            results.append({"ref": ref_path, "fetched": str(out_path), "ok": all_ok})
+            results.append({"ref": ref_path, "fetched": str(out_path), "ok": True})
         else:
-            results.append({"ref": ref_path, "ok": False, "error": "all sources failed"})
+            stale_path = FETCHED_DIR / Path(ref_path).name
+            if stale_path.exists():
+                stale_path.unlink()
+            results.append({"ref": ref_path, "ok": False, "error": "one or more sources failed"})
 
     success = sum(1 for r in results if r["ok"])
+    failed = len(results) - success
     print(f"\n{'='*50}")
     print(f"Fetched {success}/{len(results)} reference(s)")
-    if success:
+    if failed:
+        print(f"  {failed} incomplete — no stale or partial staged file remains")
+    if success and not failed:
         print(f"\nNext steps for Claude:")
         print(f"  1. Read each file in _fetched/")
         print(f"  2. Read the corresponding file in references/")
@@ -120,6 +136,7 @@ def main():
         for r in results:
             if r.get("fetched"):
                 print(f"  {r['fetched']}")
+    return 1 if failed else 0
 
 if __name__ == "__main__":
-    main()
+    sys.exit(main())

--- a/skills/client-config-copilotcli/sources.json
+++ b/skills/client-config-copilotcli/sources.json
@@ -8,7 +8,7 @@
         "https://docs.github.com/en/copilot/how-tos/copilot-cli/set-up-copilot-cli/authenticate-copilot-cli",
         "https://docs.github.com/en/copilot/concepts/agents/about-copilot-cli"
       ],
-      "covers": "config.json (trusted_folders), CLI permission flags (tools/paths/URLs), authentication, BYOK models, environment variables, interactive slash commands"
+      "covers": "config.json (trustedFolders), CLI permission flags (tools/paths/URLs), authentication, BYOK models, environment variables, interactive slash commands"
     },
     "references/mcp.md": {
       "urls": [

--- a/skills/client-config-opencode/SKILL.md
+++ b/skills/client-config-opencode/SKILL.md
@@ -14,13 +14,14 @@ You help the user manage all opencode configuration files.
 | Core settings | `~/.config/opencode/opencode.json` | Global |
 | Core settings | `opencode.json` (project root) | Project |
 | TUI / keybinds / theme | `~/.config/opencode/tui.json` | Global |
+| TUI / keybinds / theme | `tui.json` (project root) | Project |
 | Agents | `~/.config/opencode/agents/<name>.md` | Global |
 | Agents | `.opencode/agents/<name>.md` | Project |
 | Commands | `~/.config/opencode/commands/<name>.md` | Global |
 | Commands | `.opencode/commands/<name>.md` | Project |
 | Auth / credentials | `~/.local/share/opencode/auth.json` | Global (managed by CLI) |
 
-**Env overrides**: `OPENCODE_CONFIG` (custom config path), `OPENCODE_CONFIG_CONTENT` (inline JSON)
+**Env overrides**: `OPENCODE_CONFIG` (custom config path), `OPENCODE_CONFIG_CONTENT` (inline JSON), `OPENCODE_CONFIG_DIR` (custom agents, commands, modes, and plugins directory), and `OPENCODE_TUI_CONFIG` (custom TUI config path)
 
 **Merge behavior**: All config files are **merged together**, not replaced. Later configs only override conflicting keys.
 
@@ -72,7 +73,7 @@ You help the user manage all opencode configuration files.
 { "enabled_providers": ["anthropic", "openai"] }
 
 // Disable a provider
-{ "disabled_providers": ["bedrock"] }
+{ "disabled_providers": ["amazon-bedrock"] }
 
 // Log level
 { "logLevel": "INFO" }   // "DEBUG" | "INFO" | "WARN" | "ERROR"
@@ -101,10 +102,11 @@ Run with: `python scripts/<script>.py`
 
 When the user asks to **update**, **refresh**, or **sync** this skill:
 
-1. Run `python scripts/update-references.py --all` → fetches docs to `_fetched/`
-2. Read each `_fetched/` file alongside its corresponding `references/` file
-3. Update `references/` files to reflect documentation changes
-4. Delete `_fetched/` and report what changed
+1. Run `python scripts/update-references.py` → fetches docs to `_fetched/`
+2. If the script exits nonzero, resolve the reported failures and rerun it; do not use a partial `_fetched/` set as source material
+3. Read each `_fetched/` file alongside its corresponding `references/` file
+4. Update `references/` files to reflect documentation changes
+5. Delete `_fetched/` and report what changed
 
 Source URLs are in `sources.json`.
 

--- a/skills/client-config-opencode/scripts/show-config.py
+++ b/skills/client-config-opencode/scripts/show-config.py
@@ -7,15 +7,31 @@ import sys
 from pathlib import Path
 
 # Config locations
-CONFIG_DIR = Path.home() / ".config" / "opencode"
-PROJECT_DIR = Path.cwd() / ".opencode"
+CONFIG_DIR = Path(os.environ.get("XDG_CONFIG_HOME", Path.home() / ".config")) / "opencode"
+
+
+def find_project_root(start):
+    """Find the nearest OpenCode config or Git repository from the working directory."""
+    current = start.resolve()
+    for directory in (current, *current.parents):
+        if (directory / "opencode.json").exists() or (directory / ".git").exists():
+            return directory
+    return current
+
+
+PROJECT_ROOT = find_project_root(Path.cwd())
+PROJECT_DIR = PROJECT_ROOT / ".opencode"
 OPENCODE_JSON = CONFIG_DIR / "opencode.json"
-PROJECT_OPENCODE_JSON = PROJECT_DIR / "opencode.json"
-TUI_JSON = CONFIG_DIR / "tui.json"
+PROJECT_OPENCODE_JSON = PROJECT_ROOT / "opencode.json"
+TUI_JSON = Path(os.environ.get("OPENCODE_TUI_CONFIG", CONFIG_DIR / "tui.json")).expanduser()
+PROJECT_TUI_JSON = PROJECT_ROOT / "tui.json"
 AGENTS_DIR = CONFIG_DIR / "agents"
 PROJECT_AGENTS_DIR = PROJECT_DIR / "agents"
 COMMANDS_DIR = CONFIG_DIR / "commands"
 PROJECT_COMMANDS_DIR = PROJECT_DIR / "commands"
+CONFIG_OVERRIDE = os.environ.get("OPENCODE_CONFIG")
+CONFIG_CONTENT_OVERRIDE = os.environ.get("OPENCODE_CONFIG_CONTENT")
+CONFIG_DIRECTORY_OVERRIDE = os.environ.get("OPENCODE_CONFIG_DIR")
 
 BOLD = "\033[1m"
 DIM = "\033[2m"
@@ -46,6 +62,15 @@ def show_json_file(path, label):
         print(f"\n{YELLOW}{label}{RESET} ({path}) — parse error: {e}")
         with open(path, encoding="utf-8") as f:
             print(f.read())
+
+def show_json_content(content, label):
+    try:
+        data = json.loads(content)
+    except json.JSONDecodeError as e:
+        print(f"\n{YELLOW}{label}{RESET} — parse error: {e}")
+        return
+    print(f"\n{GREEN}{label}{RESET}")
+    print(json.dumps(data, indent=2))
 
 def show_md_file(path, label):
     if not path.exists():
@@ -100,31 +125,48 @@ def main():
     print(f"Working directory: {Path.cwd()}")
 
     # User-level config
-    header("User Config (~/.config/opencode/opencode.json)")
+    header(f"User Config ({OPENCODE_JSON})")
     show_json_file(OPENCODE_JSON, "opencode.json")
 
     # Project-level config
-    header("Project Config (.opencode/opencode.json)")
+    header(f"Project Config ({PROJECT_OPENCODE_JSON})")
     if PROJECT_OPENCODE_JSON.resolve() == OPENCODE_JSON.resolve():
         note("Same as user config (running from home directory)")
     else:
         show_json_file(PROJECT_OPENCODE_JSON, "opencode.json")
 
+    # Environment-provided config overrides
+    if CONFIG_OVERRIDE or CONFIG_CONTENT_OVERRIDE:
+        header("Configuration Overrides")
+        if CONFIG_OVERRIDE:
+            show_json_file(Path(CONFIG_OVERRIDE).expanduser(), "OPENCODE_CONFIG")
+        if CONFIG_CONTENT_OVERRIDE:
+            show_json_content(CONFIG_CONTENT_OVERRIDE, "OPENCODE_CONFIG_CONTENT")
+
     # TUI config
-    header("TUI Config (~/.config/opencode/tui.json)")
+    header(f"TUI Config ({TUI_JSON})")
     show_json_file(TUI_JSON, "tui.json")
+    if PROJECT_TUI_JSON != TUI_JSON:
+        header(f"Project TUI Config ({PROJECT_TUI_JSON})")
+        show_json_file(PROJECT_TUI_JSON, "tui.json")
 
     # Agents
     header("Custom Agents")
-    show_directory_contents(AGENTS_DIR, "Global agents (~/.config/opencode/agents/)")
+    show_directory_contents(AGENTS_DIR, f"Global agents ({AGENTS_DIR})")
     if PROJECT_AGENTS_DIR.exists():
         show_directory_contents(PROJECT_AGENTS_DIR, "Project agents (.opencode/agents/)")
 
     # Custom commands
     header("Custom Commands")
-    show_directory_contents(COMMANDS_DIR, "Global commands (~/.config/opencode/commands/)")
+    show_directory_contents(COMMANDS_DIR, f"Global commands ({COMMANDS_DIR})")
     if PROJECT_COMMANDS_DIR.exists():
         show_directory_contents(PROJECT_COMMANDS_DIR, "Project commands (.opencode/commands/)")
+
+    if CONFIG_DIRECTORY_OVERRIDE:
+        custom_dir = Path(CONFIG_DIRECTORY_OVERRIDE).expanduser()
+        header(f"Custom Config Directory ({custom_dir})")
+        show_directory_contents(custom_dir / "agents", "Custom agents")
+        show_directory_contents(custom_dir / "commands", "Custom commands")
 
     # Themes
     themes_dir = CONFIG_DIR / "themes"

--- a/skills/client-config-opencode/scripts/update-references.py
+++ b/skills/client-config-opencode/scripts/update-references.py
@@ -43,7 +43,7 @@ def sanitize_filename(url: str) -> str:
 def main():
     if not SOURCES_FILE.exists():
         print(f"ERROR: sources.json not found at {SOURCES_FILE}")
-        sys.exit(1)
+        return 1
 
     with open(SOURCES_FILE, encoding="utf-8") as f:
         sources = json.load(f)
@@ -92,10 +92,14 @@ def main():
         except urllib.error.HTTPError as e:
             msg = f"HTTP {e.code}: {url}"
             print(f"    ERROR: {msg}")
+            if out_path.exists():
+                out_path.unlink()
             errors.append(msg)
         except Exception as e:
             msg = f"{e}: {url}"
             print(f"    ERROR: {msg}")
+            if out_path.exists():
+                out_path.unlink()
             errors.append(msg)
         print()
 
@@ -108,12 +112,13 @@ def main():
         print(f"\n{len(errors)} error(s):")
         for e in errors:
             print(f"  - {e}")
-        sys.exit(1)
+        return 1
     else:
         print(f"\nAll {len(urls_to_fetch)} URLs fetched successfully.")
         print("\nNext step: Review diffs between _fetched/ content and references/,")
         print("then rewrite any reference files that contain stale information.")
+        return 0
 
 
 if __name__ == "__main__":
-    main()
+    sys.exit(main())


### PR DESCRIPTION
## What does this PR do?

Refreshes five agent and client-configuration skills against their official upstream documentation, while hardening their reference-refresh helpers against stale partial output.

## Type of change

- [x] New or updated skill
- [x] Tool/configuration update
- [x] Bug fix / correction

## Changes made

- Updated Copilot and OpenCode agent metadata, tools, links, properties, and permission examples.
- Corrected Claude Code and Copilot CLI configuration references, paths, and validation behavior.
- Extended OpenCode config discovery and display for current project and environment override behavior.
- Made reference updaters fail clearly and remove stale failed-fetch content.

## Checklist

- [x] All fenced code blocks have a language specifier
- [x] All links resolve correctly
- [x] No hardcoded secrets or tokens
- [x] Related docs updated in this same PR

## Tested with

- Python compilation and hermetic tests for validation, configuration display, and failed-refresh cleanup
- Current official GitHub, Claude Code, and OpenCode documentation